### PR TITLE
Add context core fn

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,9 @@ source-repository-package
     location: https://github.com/cgohla/bash
     tag: 77e0c884524606cd9beaff1f4bfa84b97d7657a4
     subdir: hs
+
+source-repository-package
+    type: git
+    location: /home/bgohla/src/scratch/singletons-lists-props
+    tag: 607225f736399f7b3dfc05815447d2dcab159671
+

--- a/pureshell.cabal
+++ b/pureshell.cabal
@@ -31,7 +31,7 @@ executable examples
   -- other-extensions:
   build-depends:
     , aeson
-    , base            ^>=4.16.3.0
+    , base        ^>=4.16.3.0
     , bash
     , bytestring
     , natural
@@ -52,7 +52,7 @@ executable pureshell
   -- other-extensions:
   build-depends:
     , aeson
-    , base            ^>=4.16.3.0
+    , base        ^>=4.16.3.0
     , bash
     , bytestring
     , purescript
@@ -67,7 +67,7 @@ library
   default-language: Haskell2010
   build-depends:
     , aeson
-    , base                  ^>=4.16.3.0
+    , base                    ^>=4.16.3.0
     , bash
     , binary
     , bytestring
@@ -83,8 +83,9 @@ library
     , purescript
     , shell-escape
     , singletons
-    , singletons-th
     , singletons-base
+    , singletons-lists-props
+    , singletons-th
     , template-haskell
     , temporary
     , text
@@ -102,9 +103,11 @@ library
     Language.PureShell.Combinatory.IR
     Language.PureShell.Combinatory.Lower
     Language.PureShell.Combinatory.Shell
+    Language.PureShell.ContextCoreFn.IR
     Language.PureShell.CoreFn.CodeGen
     Language.PureShell.CoreFn.IR
     Language.PureShell.CoreFn.Lower
+    Language.PureShell.CoreFn.LowerToContextCoreFn
     Language.PureShell.Identifiers
     Language.PureShell.Main
     Language.PureShell.Procedural.CodeGen

--- a/pureshell/Language/PureShell/ContextCoreFn/IR.hs
+++ b/pureshell/Language/PureShell/ContextCoreFn/IR.hs
@@ -1,0 +1,282 @@
+{-# LANGUAGE AllowAmbiguousTypes      #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DeriveFunctor            #-}
+{-# LANGUAGE EmptyCase                #-}
+{-# LANGUAGE ExplicitNamespaces       #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE IncoherentInstances      #-}
+{-# LANGUAGE InstanceSigs             #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
+{-# LANGUAGE OverlappingInstances     #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE PolyKinds                #-}
+{-# LANGUAGE QuasiQuotes              #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE StandaloneDeriving       #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskell          #-}
+{-# LANGUAGE TypeApplications         #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableInstances     #-}
+module Language.PureShell.ContextCoreFn.IR where
+
+import           Data.Bool.Singletons
+import           Data.Eq.Singletons
+import           Data.Functor.Singletons
+import           Data.Functor.Singletons             (FmapSym0, sFmap)
+import           Data.Kind                           (Type)
+import           Data.List.Singletons
+import           Data.Maybe.Singletons               (JustSym0, NothingSym0,
+                                                      SMaybe (..))
+import           Data.Ord.Singletons
+import           Data.Singletons                     (Sing, SingI, sing)
+import           Data.Singletons.Base.TH             (FromInteger, FromString)
+import           Data.Singletons.Prelude.List.Props5 (IsElement (..))
+import           Data.Singletons.TH                  (genSingletons, promote,
+                                                      singDecideInstances,
+                                                      singletons)
+import           Data.Singletons.TH.Options          (defaultOptions,
+                                                      defunctionalizedName,
+                                                      promotedDataTypeOrConName,
+                                                      withOptions)
+import           Data.Text                           (Text)
+import           GHC.TypeLits                        (Nat)
+import           GHC.TypeLits.Singletons             (Symbol)
+import           Language.Haskell.TH                 (Name)
+import           Language.PureScript.AST.SourcePos   (SourceSpan)
+import           Language.PureScript.Comments        (Comment)
+import qualified Language.PureScript.Names           as F (ProperName,
+                                                           ProperNameType (..),
+                                                           Qualified (..))
+import           Language.PureScript.PSString        (PSString)
+import           Text.Show.Singletons                ()
+
+-- | Like CoreFn, but with context annotations
+
+data InternalIdentData
+  = RuntimeLazyFactory
+  | Lazy !Text
+--   deriving (Show, Eq, Ord)
+
+-- | Unfortunately we can not use Language.PureScript.Names.ModuleName
+-- here because in order to generate SDecide instances, we must be
+-- able to derive our own Eq instance in the TH splice below.
+newtype ModuleName = ModuleName Text
+-- | We need this custom promoted version ModuleName. The `P` prefixed
+-- names are needed unfortunately to make the promotion hack below
+-- work.
+newtype PModuleName = PModuleName Symbol
+--   deriving (Ord, Eq, Show)
+
+data Imported a = Imported ModuleName a
+data PImported a = PImported PModuleName a
+
+data Qualified a = Qualified (Maybe ModuleName) a
+--  deriving (Ord, Eq, Show)
+data PQualified a = PQualified (Maybe PModuleName) a
+--  deriving (Ord, Eq, Show)
+
+type PQIdent = PQualified PIdent
+
+-- | We can't reuse the def'n from Language.PureScript.Names because
+-- that uses Integers instead of Nats.
+data Ident
+   = Ident Text
+   | GenIdent (Maybe Text) Nat
+   | UnusedIdent
+--   deriving (Ord, Eq, Show)
+
+data PIdent
+   = PIdent Symbol
+   | PGenIdent (Maybe Symbol) Nat
+   | PUnusedIdent
+--   deriving (Ord, Eq, Show)
+
+$(let
+     customPromote :: Name -> Name
+     customPromote n
+       | n == ''Imported = ''PImported
+       | n == 'Imported = 'PImported
+       | n == ''Ident  = ''PIdent
+       | n == 'Ident = 'PIdent
+       | n == 'GenIdent = 'PGenIdent
+       | n == 'UnusedIdent = 'PUnusedIdent
+       | n == ''Text     = ''Symbol
+       | n == ''ModuleName = ''PModuleName
+       | n == 'ModuleName = 'PModuleName
+       | n == ''Qualified = ''PQualified
+       | n == 'Qualified = 'PQualified
+       | otherwise       = promotedDataTypeOrConName defaultOptions n
+
+     customDefun :: Name -> Int -> Name
+     customDefun n sat = defunctionalizedName defaultOptions (customPromote n) sat
+ in
+    withOptions defaultOptions{ promotedDataTypeOrConName = customPromote
+                              , defunctionalizedName      = customDefun
+                              } $
+    do
+      let ts = [''Ident, ''ModuleName, ''Qualified, ''Imported]
+      a <- genSingletons ts
+      c <- singletons [d|
+                        local :: Ident -> Qualified Ident
+                        local = Qualified Nothing
+                        locals :: [Ident] -> [Qualified Ident]
+                        locals = fmap local
+                        import_ :: Imported a -> Qualified a
+                        import_ (Imported m i) = Qualified (Just m) i
+                        imports :: [Imported a] -> [Qualified a]
+                        imports = fmap import_
+
+                        deriving instance Eq Ident
+                        deriving instance Eq ModuleName
+                        deriving instance (Eq a) => Eq (Qualified a)
+                        deriving instance (Eq a) => Eq (Imported a)
+
+                        -- TODO awaiting solution of
+                        -- https://github.com/goldfirere/singletons/issues/538
+                        -- deriving instance Show Ident
+                        -- deriving instance Show ModuleName
+                        -- deriving instance (Show a) => Show (Qualified a)
+                        -- deriving instance (Show a) => Show (Imported a)
+
+                        deriving instance Ord Ident
+                        deriving instance Ord ModuleName
+                        deriving instance (Ord a) => Ord (Qualified a)
+                        deriving instance (Ord a) => Ord (Imported a)
+
+                        deriving instance Functor Qualified
+                        deriving instance Functor Imported
+
+                        |]
+      return $ a <> c
+ )
+
+data Literal a c
+   = NumericLiteral (Either Integer Double)
+   | StringLiteral PSString
+   | CharLiteral Char
+   | BooleanLiteral Bool
+   | ArrayLiteral [Expr a c]
+   | ObjectLiteral [(PSString, Expr a c)]
+
+data Expr a (c :: [PQIdent]) where
+  Constructor  :: a -> (F.ProperName 'F.TypeName) -> (F.ProperName 'F.ConstructorName) -> Sing (fs :: [PIdent]) -> Expr a c
+  -- ^ This is like a lambda
+  Accessor     :: a -> PSString -> (Expr a c) -> Expr a c -- ^ This is like an application
+  ObjectUpdate :: a -> (Expr a c) -> [(PSString, Expr a c)] -> Expr a c -- ^ This is like an application
+  Literal      :: a -> Literal a c -> Expr a c
+  Abs          :: a -> Sing (i :: PIdent) -> (Expr a ((Local i) ': c)) -> Expr a c
+  App          :: a -> Expr a c -> Expr a c -> Expr a c
+  Var          :: a -> Sing (i :: PQIdent) -> IsElement i c -> Expr a c
+  Case         :: a -> [Expr a c] -> [CaseAlternative a c] -> Expr a c
+  -- ^ NOTE As is this does not guarantee that there are enough
+  -- expressions for the binders in each branch
+  Let          :: a -> BindList a l c -> {- in -} Expr a ((Locals l) ++ c) -> Expr a c
+
+data BindList a (l :: [PIdent]) (c :: [PQIdent]) where
+  BindListNil :: BindList a '[] c
+  BindListCons :: Bind a l c -> BindList a l' c -> BindList a (l ++ l') c
+
+data Bind a (l :: [PIdent]) (c :: [PQIdent]) where
+   NonRec :: a -> (Sing (i :: PIdent)) {- = -} -> (Expr a c) -> Bind a '[i] c
+   Rec    :: RecList a l ((Locals l) ++ c) -> Bind a l c
+
+-- | We track the list of names bound in a recursive let block in the
+-- type parameter l. To make those names available inside all bound
+-- expressions, l needs to be appended to the context c where RecList
+-- is used.
+data family RecList a (l :: [PIdent]) (c :: [PQIdent]) :: Type
+data instance RecList a '[] c = RecNil
+data instance RecList a (i ': is) c = RecCons a (Sing i) {- = -} (Expr a c)
+                                      {- : -} (RecList a is c)
+
+type Guard a c = Expr a c
+
+data LitBinderArray a (l :: [PIdent]) where
+  LitBinderArrayNil :: LitBinderArray a '[]
+  LitBinderArrayCons :: Binder a l {- : -} -> LitBinderArray a l'
+                     -> LitBinderArray a (l ++ l')
+
+data LitBinderObject a (l :: [PIdent]) where
+  LitBinderObjectNil :: LitBinderObject a '[]
+  LitBinderObjectCons :: PSString
+                      -> Binder a l {- : -}
+                      -> LitBinderObject a l'
+                      -> LitBinderObject a (l ++ l')
+
+-- | NOTE we can't reuse the Literal type from CoreFn because we need
+-- to accumulate names.
+data LitBinder a (l :: [PIdent]) where
+   NumericLitBinder :: (Either Integer Double) -> LitBinder a '[]
+   StringLitBinder  :: PSString -> LitBinder a '[]
+   CharLitBinder    :: Char -> LitBinder a '[]
+   BooleanLitBinder :: Bool -> LitBinder a '[]
+   ArrayLitBinder   :: LitBinderArray a l -> LitBinder a l
+   ObjectLitBinder  :: LitBinderObject a l -> LitBinder a l
+
+type TypeName = (F.Qualified (F.ProperName 'F.TypeName))
+type ConstructorName = (F.Qualified (F.ProperName 'F.ConstructorName))
+
+data Binder a (l :: [PIdent]) where
+ NullBinder        :: a -> Binder a '[]
+ LiteralBinder     :: a -> LitBinder a l -> Binder a l
+ -- ^ TODO It's not clear this is correct
+ VarBinder         :: a -> Sing (i :: PIdent) -> Binder a '[i]
+ ConstructorBinder :: a -> TypeName -> ConstructorName -> BinderList a l -> Binder a l
+ NamedBinder       :: a -> Sing (i :: PIdent) -> Binder a l -> Binder a (i ': l)
+
+data BinderList a (l :: [PIdent]) where
+  BinderListNil :: BinderList a '[]
+  BinderListCons :: Binder a l -> BinderList a l' -> BinderList a (l ++ l')
+
+data CaseAlternative a c = forall (l :: [PIdent]). CaseAlternative
+   { caseAlternativeBinders :: BinderList a l
+   , caseAlternativeResult  :: Either [(Guard a (Locals l ++ c), Expr a (Locals l ++ c))] (Expr a (Locals l ++ c))
+   }
+
+example0 :: Expr () '[]
+example0 = Let () (BindListCons
+                    (Rec (RecCons ()
+                          (sing @('PIdent "bar")) {- = -} (Var () (sing @('PQualified 'Nothing ('PIdent "bar"))) (IsElementHead sing sing) ) $
+                         -- ^ NOTE This is legal in a LetRec. We must
+                         -- take care when lowering though: recursion in
+                         -- bash must use functions.
+                          RecCons ()
+                          (sing @('PIdent "foo")) {- = -} (Literal () $ BooleanLiteral True)
+                          RecNil
+                         )
+                    )
+                    BindListNil
+                  )
+           (Var () (sing @('PQualified 'Nothing ('PIdent "foo"))
+                   )
+             (IsElementTail sing $ IsElementHead sing sing)
+           )
+
+example1 :: Expr () '[ Local('PIdent "foo")]
+example1 = Case () [Var () (sing @(Local('PIdent "foo"))) $ IsElementHead sing sing]
+           [ {- match -} CaseAlternative (BinderListCons (LiteralBinder () $ BooleanLitBinder False ) BinderListNil)
+             {- then -} (Right $ Literal () $ BooleanLiteral True)
+           ]
+
+data Module a = forall l f i. Module
+  { moduleSourceSpan :: SourceSpan
+  , moduleComments   :: [Comment]
+  , moduleName       :: ModuleName
+  , modulePath       :: FilePath
+  -- , moduleImports    :: [(a, ModuleName)]
+  -- , moduleExports    :: [Ident]
+  -- , moduleReExports  :: Map ModuleName [Ident]
+  -- NOTE Since Bash has no notion of modules or name spaces we have
+  -- no use for these.
+  , moduleImports    :: Sing (i :: [PImported PIdent])
+  -- ^ This is an enumeration of all imported symbols, not just module
+  -- names as in CoreFn. We will need to compute this information.
+  , moduleForeign    :: Sing (f :: [PIdent])
+  , moduleDecls      :: BindList a l (Imports i ++ Locals f)
+  }

--- a/pureshell/Language/PureShell/CoreFn/LowerToContextCoreFn.hs
+++ b/pureshell/Language/PureShell/CoreFn/LowerToContextCoreFn.hs
@@ -1,0 +1,244 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ExplicitNamespaces  #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE InstanceSigs        #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+module Language.PureShell.CoreFn.LowerToContextCoreFn (lowerModule) where
+
+import           Control.Applicative.Singletons      (sPure)
+import           Data.Bifunctor                      (bimap, second)
+import           Data.List                           (nub)
+import           Data.List.Singletons                (SList (..), type (++),
+                                                      (%++))
+import           Data.Map.Strict                     as M (fromList, keys,
+                                                           lookup, type Map)
+import           Data.Maybe                          (fromMaybe)
+import           Data.Singletons                     (Sing, fromSing,
+                                                      withSomeSing)
+import           Data.Singletons.Decide              (type (:~:) (..))
+import           Data.Singletons.Prelude.List.Props5 (decideIsElement)
+
+import qualified Language.PureShell.ContextCoreFn.IR as X
+import qualified Language.PureShell.CoreFn.IR        as F
+
+lowerModule :: F.Module a -> X.Module a
+lowerModule m =
+  withSomeSing (elaborateIdents $ F.moduleForeign m) $ \f ->
+  withSomeSing (nub $ findImportedSymbols $ F.moduleDecls m) $ \i ->
+  case (elaborateBindList (X.sImports i %++ X.sLocals f) $ F.moduleDecls m) of
+    (SomeBindList _ d) ->
+      X.Module
+      { X.moduleSourceSpan = F.moduleSourceSpan m
+      , X.moduleComments   = F.moduleComments m
+      , X.moduleName       = case F.moduleName m of
+                                F.ModuleName n -> X.ModuleName n
+      , X.modulePath       = F.modulePath m
+      , X.moduleImports    = i
+      , X.moduleForeign    = f
+      , X.moduleDecls      = d
+      }
+
+findImportedSymbols :: [F.Bind a] -> [X.Imported X.Ident]
+findImportedSymbols = foldl findImportedSymbolsBind []
+  where
+    findImportedSymbolsBind acc = \case
+      F.NonRec _ _ e -> findImportedSymbolsInExpr acc e
+      F.Rec bs       -> foldl findImportedSymbolsInExpr acc $ snd <$> bs
+    findImportedSymbolsInExpr acc = \case
+      (F.Literal _ l)         -> findImportedSymbolsInLiteral acc l
+      (F.Constructor _ _ _ _) -> acc
+      (F.Accessor _ _ e)      -> findImportedSymbolsInExpr acc e
+      (F.ObjectUpdate _ e us) -> let a = findImportedSymbolsInExpr acc e in
+                                    foldl findImportedSymbolsInExpr a $ snd <$> us
+      (F.Abs _ _ e)           -> findImportedSymbolsInExpr acc e
+      (F.App _ e e')          -> let a = findImportedSymbolsInExpr acc e in
+                                     findImportedSymbolsInExpr a e'
+      (F.Var _ (F.Qualified (F.ByModuleName (F.ModuleName m)) (F.Ident i))) ->
+        X.Imported (X.ModuleName m) (X.Ident i) : acc
+        -- ^ NOTE This is the heart of it: An imported symbol is one
+        -- qualified by a module name; all others by implication are local
+        -- references. This assumption may turn out to be wrong.
+      (F.Var _ _)             -> acc
+      (F.Case _ es as)        -> let a = foldl findImportedSymbolsInExpr acc es in
+                                      foldl findImportedSymbolsInCA a as
+      (F.Let _ bs e)          -> let a = foldl findImportedSymbolsBind acc bs in
+                                    findImportedSymbolsInExpr a e
+    findImportedSymbolsInLiteral acc = \case
+      (F.ArrayLiteral ls)  -> foldl findImportedSymbolsInExpr acc ls
+      (F.ObjectLiteral rs) -> foldl findImportedSymbolsInExpr acc $ snd <$> rs
+      _                    -> acc
+    findImportedSymbolsInCA acc (F.CaseAlternative _ r) = case r of
+      Left gdes -> let unpackGuards =
+                         foldl (\a -> \(x,y) -> x:y:a) []
+                   in
+                     foldl findImportedSymbolsInExpr acc $
+                     unpackGuards gdes
+      Right e -> findImportedSymbolsInExpr acc e
+
+elaborateIdents :: [F.Ident] -> [X.Ident]
+elaborateIdents = fmap elaborateIdent
+
+elaborateIdent :: F.Ident -> X.Ident
+elaborateIdent (F.Ident t)      = X.Ident t
+elaborateIdent (F.GenIdent t i) = X.GenIdent t (fromInteger i)
+-- fromInteger is obviously partial and may crash
+elaborateIdent F.UnusedIdent    = X.UnusedIdent
+elaborateIdent _                = error "impossible"
+
+elaborateQualifiedIdent :: F.Qualified F.Ident -> X.Qualified X.Ident
+elaborateQualifiedIdent (F.Qualified m i) = X.Qualified (f m) $ elaborateIdent i
+  where
+    f (F.ByModuleName (F.ModuleName n)) = Just $ X.ModuleName n
+    f _                                 = error "not implemented"
+
+elaborateLiteral :: Sing c -> F.Literal (F.Expr a) -> X.Literal a c
+elaborateLiteral _ (F.NumericLiteral n) = X.NumericLiteral n
+elaborateLiteral _ (F.StringLiteral s)  = X.StringLiteral s
+elaborateLiteral _ (F.CharLiteral c)    = X.CharLiteral c
+elaborateLiteral _ (F.BooleanLiteral b) = X.BooleanLiteral b
+elaborateLiteral c (F.ArrayLiteral as)  = X.ArrayLiteral $
+  fmap (elaborateExpr c) as
+elaborateLiteral c (F.ObjectLiteral as)  = X.ObjectLiteral $
+  fmap (second $ elaborateExpr c) as
+
+data SomeLitBinderArray a = forall l. SomeLitBinderArray (Sing l) (X.LitBinderArray a l)
+
+elaborateLitBinderArray :: [F.Binder a] -> SomeLitBinderArray a
+elaborateLitBinderArray []       = SomeLitBinderArray SNil X.LitBinderArrayNil
+elaborateLitBinderArray (b : bs) = case elaborateBinder b of
+                                     SomeBinder l b' -> case elaborateLitBinderArray bs of
+                                       SomeLitBinderArray l' bs' ->
+                                         SomeLitBinderArray (l %++ l') $ X.LitBinderArrayCons b' bs'
+
+data SomeLitBinder a = forall l. SomeLitBinder (Sing l) (X.LitBinder a l)
+
+data SomeLitBinderObject a = forall l. SomeLitBinderObject (Sing l) (X.LitBinderObject a l)
+
+elaborateLitBinderObject :: [(F.PSString, F.Binder a)] -> SomeLitBinderObject a
+elaborateLitBinderObject []       = SomeLitBinderObject SNil X.LitBinderObjectNil
+elaborateLitBinderObject ((f,b) : bs) = case elaborateBinder b of
+                                          SomeBinder l b' -> case elaborateLitBinderObject bs of
+                                            SomeLitBinderObject l' bs' ->
+                                              SomeLitBinderObject (l %++ l') $ X.LitBinderObjectCons f b' bs'
+
+elaborateLitBinder :: F.Literal (F.Binder a) -> SomeLitBinder a
+elaborateLitBinder = \case
+  F.NumericLiteral n      -> SomeLitBinder SNil $ X.NumericLitBinder n
+  F.StringLiteral s       -> SomeLitBinder SNil $ X.StringLitBinder s
+  F.CharLiteral c         -> SomeLitBinder SNil $ X.CharLitBinder c
+  F.BooleanLiteral b      -> SomeLitBinder SNil $ X.BooleanLitBinder b
+  F.ArrayLiteral a        -> case elaborateLitBinderArray a of
+                               SomeLitBinderArray l a' -> SomeLitBinder l $ X.ArrayLitBinder a'
+  F.ObjectLiteral o      -> case elaborateLitBinderObject o of
+                               SomeLitBinderObject l o' -> SomeLitBinder l $ X.ObjectLitBinder o'
+
+data SomeBinder a = forall l. SomeBinder (Sing l) (X.Binder a l)
+
+elaborateBinder :: F.Binder a -> SomeBinder a
+elaborateBinder b = case b of
+  F.NullBinder a               -> SomeBinder SNil $ X.NullBinder a
+  F.LiteralBinder a l          -> case elaborateLitBinder l of
+                                    SomeLitBinder l' b' -> SomeBinder l' $ X.LiteralBinder a b'
+  F.VarBinder a i              -> withSomeSing (elaborateIdent i) $
+                                  \i' -> SomeBinder (sPure i') $ X.VarBinder a i'
+  F.ConstructorBinder a t n bs -> case elaborateBinderList bs of
+                                    SomeBinderList l bs' -> SomeBinder l $ X.ConstructorBinder a t n bs'
+  F.NamedBinder a i z          -> withSomeSing (elaborateIdent i) $
+                                  \i' -> case (elaborateBinder z) of
+                                    SomeBinder l d -> SomeBinder (SCons i' l) $ X.NamedBinder a i' d
+
+data SomeBinderList a = forall l. SomeBinderList (Sing l) (X.BinderList a l)
+
+elaborateBinderList :: [F.Binder a] -> SomeBinderList a
+elaborateBinderList []       = SomeBinderList SNil X.BinderListNil
+elaborateBinderList (b : bs) = case elaborateBinder b of
+                                 SomeBinder l b' -> case elaborateBinderList bs of
+                                   SomeBinderList l' bs' -> SomeBinderList (l %++ l') $
+                                     X.BinderListCons b' bs'
+
+elaborateCaseAlternative :: Sing c -> F.CaseAlternative a -> X.CaseAlternative a c
+elaborateCaseAlternative c (F.CaseAlternative bs rd) = case (elaborateBinderList bs) of
+                                                         SomeBinderList l bs' -> case rd of
+                                                           Left gs -> X.CaseAlternative bs' $
+                                                                      Left $ fmap (bimap elab elab) gs
+                                                           Right r -> X.CaseAlternative bs' $
+                                                                      Right $ elab r
+                                                           where
+                                                             elab = elaborateExpr (X.sLocals l %++ c)
+
+elaborateExpr :: Sing c -> F.Expr a -> X.Expr a c
+elaborateExpr c (F.Literal a l)          = X.Literal a $ elaborateLiteral c l
+elaborateExpr _ (F.Constructor a t n fs) = withSomeSing (elaborateIdents fs) $
+                                           \fs' -> X.Constructor a t n fs'
+elaborateExpr c (F.Accessor a f e)       = X.Accessor a f $ elaborateExpr c e
+elaborateExpr c (F.ObjectUpdate a e fs)  = X.ObjectUpdate a (elaborateExpr c e) $
+                                           fmap (second $ elaborateExpr c) fs
+elaborateExpr c (F.Abs a i e)            = withSomeSing (elaborateIdent i) $
+                                           \i' -> X.Abs a i' $ elaborateExpr (SCons (X.sLocal i') c) e
+elaborateExpr c (F.App a e e')           = X.App a (elaborateExpr c e) (elaborateExpr c e')
+elaborateExpr c (F.Var a i)              = withSomeSing (elaborateQualifiedIdent i) $
+                                           \i' -> maybe (error "Scope error in CoreFn") (X.Var a i') (decideIsElement i' c)
+elaborateExpr c (F.Case a es as)         = X.Case a (fmap (elaborateExpr c) es) $
+                                           fmap (elaborateCaseAlternative c) as
+elaborateExpr c (F.Let a bs e)           = case elaborateBindList c bs of
+                                             SomeBindList l bs' ->
+                                               X.Let a bs' $ elaborateExpr (X.sLocals l %++ c) e
+
+listRightUnit :: Sing a -> a :~: (a ++ '[])
+listRightUnit SNil = Refl
+listRightUnit (SCons _ as) = case listRightUnit as of
+                             Refl -> Refl
+
+elaborateRecList :: forall l c a. Sing l -> Sing c
+                 -> Map X.Ident (a, F.Expr a)
+                 -> X.RecList a l (X.Locals l ++ c)
+elaborateRecList l c bs = case listRightUnit l of
+                             Refl -> go l (X.sLocals l %++ c) X.RecNil
+                             -- The compiler on its own can not figure
+                             -- out that l ++ '[] ~ l for a variable
+                             -- l, so we must supply a
+                             -- proof; otherwise the return type of
+                             -- this application of 'go' does not
+                             -- match with the return type of our
+                             -- enclosing function.
+  where
+    go :: Sing l'' -> Sing c'
+       -> X.RecList a l' c' -> X.RecList a (l'' ++ l') c'
+    go SNil _ rl = rl
+    go (SCons l' ls') c' rl =
+      let
+        err = error "impossible"
+        (a, e) = fromMaybe err $ M.lookup (fromSing l') bs
+        e' = elaborateExpr c' e
+        rl' = go ls' c' rl
+      in X.RecCons a l' e' rl'
+
+data SomeBindList a c = forall l. SomeBindList (Sing l) (X.BindList a l c)
+
+data SomeBind a c = forall l. SomeBind (Sing l) (X.Bind a l c)
+
+elaborateBind :: Sing c -> F.Bind a -> SomeBind a c
+elaborateBind c (F.NonRec a i e) = withSomeSing (elaborateIdent i) $
+                                   \i' -> SomeBind (sPure i') $ X.NonRec a i' $
+                                   elaborateExpr c e
+elaborateBind c (F.Rec bs) = let bs' = exprDict bs
+                                 exprDict = M.fromList . fmap f
+                                 f = \((a, i), e) -> (elaborateIdent i, (a, e))
+                             in
+                               withSomeSing (keys bs') $
+                               \d -> SomeBind d $ X.Rec $ elaborateRecList d c bs'
+
+elaborateBindList :: Sing c -> [F.Bind a] -> SomeBindList a c
+elaborateBindList _ [] = SomeBindList SNil X.BindListNil
+elaborateBindList c (b : bs) = case elaborateBind c b of
+                            SomeBind l b' ->
+                              case elaborateBindList c bs of
+                                SomeBindList l' bs' ->
+                                  SomeBindList (l %++ l') $ X.BindListCons b' bs'


### PR DESCRIPTION
ContextCoreFn is an IR that is CoreFn with type level contexts, and
appropriate well-scopedness constraints. We also add code to elaborate
CoreFn to ContextCoreFn.